### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 FROM openjdk:13.0.1-slim-buster
 MAINTAINER Neil Best <nbest937@gmail.com>
 
-
-ENV SCALA_VERSION 2.12
-ENV COURSIER_VERSION v2.0.0-RC5-3
-ENV COURSIER_URL https://github.com/coursier/coursier/releases/download/${COURSIER_VERSION}/coursier
-ENV AMM_VERSION 1.8.1
 # ENV AMM_FILE $SCALA_VERSION-$AMM_VERSION
 # ENV AMM_URL https://github.com/lihaoyi/Ammonite/releases/download/$AMM_VERSION/$AMM_FILE
 
+RUN apt-get update && apt-get -y install curl
+
 WORKDIR /usr/local/bin
+
+ENV COURSIER_VERSION v2.0.0-RC5-3
+ENV COURSIER_URL https://github.com/coursier/coursier/releases/download/${COURSIER_VERSION}/coursier
 
 RUN curl -Lo coursier $COURSIER_URL \
  && chmod +x coursier \
@@ -21,12 +21,19 @@ RUN curl -Lo coursier $COURSIER_URL \
 WORKDIR /
 
 RUN coursier fetch \
- org.apache.spark:spark-sql:2.4.0
- 
+ org.apache.spark::spark-sql:2.4.0
+
+# RUN coursier fetch \
+#  -r jitpack \
+#  com.github.nbest937:ammonite-spark:fc59944f
+
 RUN coursier fetch \
- -r jitpack \
- com.github.nbest937:ammonite-spark:fc59944f
- 
+ -r sonatype:snapshots \
+ sh.almond:ammonite-spark_2.12:0.8.0+16-fc59944f-SNAPSHOT
+
+ENV SCALA_VERSION 2.12.10
+ENV AMM_VERSION 2.0.1
+
 RUN coursier bootstrap \
  com.lihaoyi:ammonite_${SCALA_VERSION}:${AMM_VERSION} \
  -M ammonite.Main \
@@ -34,6 +41,6 @@ RUN coursier bootstrap \
 
 # CMD amm
 
-RUN amm -c ""
+RUN ./amm -c ""
 
-CMD amm
+CMD ./amm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,39 @@
-FROM lolhens/baseimage-openjre:latest
-MAINTAINER LolHens <pierrekisters@gmail.com>
+FROM openjdk:13.0.1-slim-buster
+MAINTAINER Neil Best <nbest937@gmail.com>
 
 
-ENV SCALA_VERSION 2.13
-ENV AMM_VERSION 1.7.1
-ENV AMM_FILE $SCALA_VERSION-$AMM_VERSION
-ENV AMM_URL https://github.com/lihaoyi/Ammonite/releases/download/$AMM_VERSION/$AMM_FILE
+ENV SCALA_VERSION 2.12
+ENV COURSIER_VERSION v2.0.0-RC5-3
+ENV COURSIER_URL https://github.com/coursier/coursier/releases/download/${COURSIER_VERSION}/coursier
+ENV AMM_VERSION 1.8.1
+# ENV AMM_FILE $SCALA_VERSION-$AMM_VERSION
+# ENV AMM_URL https://github.com/lihaoyi/Ammonite/releases/download/$AMM_VERSION/$AMM_FILE
 
+WORKDIR /usr/local/bin
 
-RUN (echo '#!/usr/bin/env sh' && curl -L "$AMM_URL") > /usr/local/bin/amm \
- && chmod +x "/usr/local/bin/amm"
+RUN curl -Lo coursier $COURSIER_URL \
+ && chmod +x coursier \
+ && ./coursier --help
+
+# RUN (echo '#!/usr/bin/env sh' && curl -L "$AMM_URL") > /usr/local/bin/amm \
+# && chmod +x "/usr/local/bin/amm"
+
+WORKDIR /
+
+RUN coursier fetch \
+ org.apache.spark:spark-sql:2.4.0
+ 
+RUN coursier fetch \
+ -r jitpack
+ com.github.nbest937:ammonite-spark:fc59944f
+ 
+RUN coursier bootstrap \
+ com.lihaoyi:ammonite_${SCALA_VERSION}:${AMM_VERSION} \
+ -M ammonite.Main \
+ -o amm
+
+# CMD amm
 
 RUN amm -c ""
-
 
 CMD amm

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN coursier fetch \
  org.apache.spark:spark-sql:2.4.0
  
 RUN coursier fetch \
- -r jitpack
+ -r jitpack \
  com.github.nbest937:ammonite-spark:fc59944f
  
 RUN coursier bootstrap \


### PR DESCRIPTION
- Switch to `openjdk:13.0.1-slim-buster` image
- Use `coursier` to bootstrap `amm`
- Fetch `spark-sql` and `ammonite-spark` artifacts